### PR TITLE
feat(auth): implement logout flow with UI and API integration

### DIFF
--- a/src/api/deleteAccess/deleteAccess.ts
+++ b/src/api/deleteAccess/deleteAccess.ts
@@ -1,0 +1,5 @@
+import { ACCESS_TOKEN_KEY } from '@api/authBeforeRequest/contants';
+
+export const deleteAccess = () => {
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+}

--- a/src/components/Layout/components/types.ts
+++ b/src/components/Layout/components/types.ts
@@ -1,6 +1,7 @@
 export const enum RouteMap {
   home = '/',
   login = '/login',
+  logout = '/logout',
   register = '/register',
   namespaces = '/namespaces',
   namespace = '/namespaces/:namespace_slug',

--- a/src/scenes/Scenes.tsx
+++ b/src/scenes/Scenes.tsx
@@ -12,6 +12,7 @@ import { Projects } from './components/Projects';
 import { Project } from './components/Project';
 import { RouteMap } from '@components/Layout/components/types';
 import { CreateTemplate } from './components/CreateTemplate';
+import { Logout } from './components/Logout';
 
 export const routes = [
   {
@@ -54,6 +55,10 @@ export const routes = [
         path: RouteMap.register,
         element: <RegisterForm />,
       },
+      {
+        path: RouteMap.logout,
+        element: <Logout />
+      }
     ],
   },
 ];

--- a/src/scenes/components/Logout/Logout.tsx
+++ b/src/scenes/components/Logout/Logout.tsx
@@ -1,0 +1,25 @@
+import { useState } from "react";
+
+import { Button } from "@components/Button";
+
+import { LogoutUser } from "./api";
+
+export const Logout = () => {
+
+    const [isLoading, setIsLoading] = useState(false);
+
+    async function handleClick() {
+        setIsLoading(true);
+        await LogoutUser();
+        setIsLoading(false);
+    }
+
+    return (
+        <div className="mt-4 text-center">
+            <Button onClick={handleClick}>
+                { isLoading ? "Logging out..." : "Log out" }
+            </Button>
+        </div >
+    );
+
+}

--- a/src/scenes/components/Logout/api.ts
+++ b/src/scenes/components/Logout/api.ts
@@ -1,0 +1,21 @@
+import { authApi } from "@api/constants";
+import { deleteAccess } from "@api/deleteAccess/deleteAccess";
+
+import type { ResponseLogoutUser } from "./types";
+
+export async function LogoutUser(): Promise<ResponseLogoutUser> {
+    try {
+       
+        const response = await authApi.delete('auth/logout');
+        if (response.ok) deleteAccess();
+
+        return {
+            success: response.ok,
+            data: await response.json() 
+        } as ResponseLogoutUser;
+
+    } catch (error) {
+        console.error(error);
+        return { success: false, data: null };
+    }
+}

--- a/src/scenes/components/Logout/index.ts
+++ b/src/scenes/components/Logout/index.ts
@@ -1,0 +1,1 @@
+export { Logout } from "./Logout";

--- a/src/scenes/components/Logout/types.ts
+++ b/src/scenes/components/Logout/types.ts
@@ -1,0 +1,28 @@
+interface SuccessResponseDataLogout {
+    detail: string
+}
+interface FailureResponseDataLogout {
+    detail: [
+        {
+            loc: [
+                string,
+                0
+            ],
+            msg: string,
+            type: string
+        }
+    ]
+}
+
+type ResponseLogoutUser = (
+    {
+        success: false,
+        data: FailureResponseDataLogout | null
+    } |
+    {
+        success: true,
+        data: SuccessResponseDataLogout
+    }
+)
+
+export type { ResponseLogoutUser };


### PR DESCRIPTION
Реализован выход пользователя из аккаунта:
- Кнопка выхода вызывает API "/auth/logout"
- Удаляются все следы аутентификации (токен в хранилище (localStorage))

Ссылка на задачку: https://buildin.ai/53815573-43a9-4ec3-9a11-33c5104ec770